### PR TITLE
Add assertions

### DIFF
--- a/src/main/java/duke/task/Storage.java
+++ b/src/main/java/duke/task/Storage.java
@@ -71,14 +71,17 @@ public class Storage {
             List<String> dataList = Files.lines(filePath).collect(Collectors.toList());
             for (String line : dataList) {
                 String[] details = line.split("\\|", 4);
+                assert details.length > 2;
                 String tag = details[0];
                 Boolean done = details[1].equals("1");
                 Task task;
                 if (tag.equals("T")) {
                     task = new ToDo(details[2]);
                 } else if (tag.equals("D")) {
+                    assert details.length == 4;
                     task = new Deadline(details[2], details[3]);
                 } else if (tag.equals("E")) {
+                    assert details.length == 4;
                     task = new Event(details[2], details[3]);
                 } else {
                     throw new DukeException("Unknown tag '" + tag + "'.");

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -97,6 +97,8 @@ public class TaskList {
      * @throws DukeException
      */
     public Task markTaskDone(Integer taskNum) throws DukeException {
+        assert todoList.size() > 0;
+        
         Task task = todoList.get(taskNum - 1);
         task.markAsDone();
 
@@ -111,6 +113,8 @@ public class TaskList {
      * @throws DukeException
      */
     public Task deleteTask(Integer taskNum) throws DukeException {
+        assert todoList.size() > 0;
+
         Task task = todoList.remove(taskNum - 1);
 
         return task;

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -98,7 +98,7 @@ public class TaskList {
      */
     public Task markTaskDone(Integer taskNum) throws DukeException {
         assert todoList.size() > 0;
-        
+
         Task task = todoList.get(taskNum - 1);
         task.markAsDone();
 


### PR DESCRIPTION
* For TaskList methods markTaskDone() and deleteTask(), todoList
should have at least 1 task to work correctly.
* For Storage.load(), the task data parsed into details is
assumed to be formatted correctly containing 3 fields for ToDo
and 4 fields for Deadline and Event.

The assumptions may cause bugs and errors if not met.

Adding assertions will allow assumptions to be verified in runtime
and surface bugs if any.

Using assertions in TaskList is preferable over Exceptions as
the failed validation of taskNum should have already thrown
an Exception in Command before calling the methods in TaskList.